### PR TITLE
Add parameter allowing to skip installation of repo config files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,9 @@
 grafana_version: latest
 grafana_yum_repo_template: etc/yum.repos.d/grafana.repo.j2
 
+# Set to "true" to skip installation of custom repo config files
+grafana_use_exiting_repo_file: false
+
 # Should we use the provisioning capability when possible (provisioning require grafana >= 5.0)
 grafana_use_provisioning: true
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -36,7 +36,9 @@
     dest: "/etc/yum.repos.d/{{ grafana_yum_repo_template | basename | regex_replace('\\.j2$', '') }}"
     force: true
     backup: true
-  when: ansible_pkg_mgr in ['yum', 'dnf']
+  when:
+    - ansible_pkg_mgr in ['yum', 'dnf']
+    - not grafana_use_exiting_repo_file
 
 - block:
     - name: Import Grafana GPG signing key [Debian/Ubuntu]
@@ -60,6 +62,7 @@
       delay: 2
   when:
     - ansible_pkg_mgr == "apt"
+    - not grafana_use_exiting_repo_file
   environment: "{{ grafana_environment }}"
 
 - name: Install Grafana


### PR DESCRIPTION
In some cases (for example when using a repo mirror) repo config files may already be present on the server and with this change makes it possible to skip tasks trying to modify existing configs.