### PR TITLE
Only enable grafana repos during install

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,22 +1,14 @@
 ---
 
-- block:
-    - name: Update apt cache
-      apt:
-        update_cache: true
-      register: _pre_update_apt_cache
-      until: _pre_update_apt_cache is succeeded
-      when:
-        - ansible_pkg_mgr == "apt"
 
-    - name: Install dependencies
-      package:
-        name: "{{ grafana_dependencies }}"
-        state: present
-      register: _install_dep_packages
-      until: _install_dep_packages is succeeded
-      retries: 5
-      delay: 2
+- name: Install dependencies
+  package:
+    name: "{{ grafana_dependencies }}"
+    state: present
+  register: _install_dep_packages
+  until: _install_dep_packages is succeeded
+  retries: 5
+  delay: 2
 
 - name: Remove conflicting grafana packages
   package:
@@ -24,13 +16,7 @@
     state: absent
   register: _old_grafana_pkgs
 
-- name: Clean apt cache
-  command: apt clean
-  when:
-    - _old_grafana_pkgs is changed
-    - ansible_pkg_mgr == "apt"
-
-- name: Add Grafana repository file [RHEL/CentOS]
+- name: Add (disabled) Grafana repository file [RHEL/CentOS]
   template:
     src: "{{ grafana_yum_repo_template }}"
     dest: "/etc/yum.repos.d/{{ grafana_yum_repo_template | basename | regex_replace('\\.j2$', '') }}"
@@ -38,34 +24,25 @@
     backup: true
   when: ansible_pkg_mgr in ['yum', 'dnf']
 
-- block:
-    - name: Import Grafana GPG signing key [Debian/Ubuntu]
-      apt_key:
-        url: "https://packages.grafana.com/gpg.key"
-        state: present
-        validate_certs: false
-      register: _add_apt_key
-      until: _add_apt_key is succeeded
-      retries: 5
-      delay: 2
-
-    - name: Add Grafana repository [Debian/Ubuntu]
-      apt_repository:
-        repo: deb https://packages.grafana.com/oss/deb stable main
-        state: present
-        update_cache: true
-      register: _update_apt_cache
-      until: _update_apt_cache is succeeded
-      retries: 5
-      delay: 2
-  when:
-    - ansible_pkg_mgr == "apt"
-  environment: "{{ grafana_environment }}"
-
-- name: Install Grafana
+# Work around the fact the grafana repos are flaky: only enable them if actually required
+- name: Check whether Grafana is installed
+  # Fails with message below if not installed as repo is disabled
+  # Otherwise succeeds. No change in either case!
   package:
     name: "{{ grafana_package }}"
     state: "{{ (grafana_version == 'latest') | ternary('latest', 'present') }}"
+  check_mode: true
+  register: _existing_install
+  failed_when:
+    - _existing_install.rc != 0
+    - "'No package grafana' not in _existing_install.failures[0]"
+
+- name: Install Grafana package
+  ansible.builtin.dnf:
+    name: "{{ grafana_package }}"
+    state: "{{ (grafana_version == 'latest') | ternary('latest', 'present') }}"
+    enablerepo: grafana
+  when: "'No package grafana' in _existing_install.get('failures', [''])[0]"
   register: _install_packages
   until: _install_packages is succeeded
   retries: 5

--- a/templates/etc/yum.repos.d/grafana.repo.j2
+++ b/templates/etc/yum.repos.d/grafana.repo.j2
@@ -3,7 +3,7 @@
 name=grafana
 baseurl=https://packages.grafana.com/oss/rpm
 repo_gpgcheck=1
-enabled=1
+enabled=0
 gpgcheck=1
 gpgkey=https://packages.grafana.com/gpg.key
 sslverify=1


### PR DESCRIPTION
The grafana repos are flaky, so any dnf operations (not just those on grafana packages) can fail due to being unable to update metadata from these repos. This PR disables the grafana repo by default, only enabling it during grafana package install.

Removes support for apt given we don't use it to simplify logic changes/testing.